### PR TITLE
Fix missing metrics placeholder

### DIFF
--- a/github-metrics.svg
+++ b/github-metrics.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="200">
+  <rect width="100%" height="100%" fill="#f8f9fa"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#555">
+    Metrics unavailable
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add a placeholder `github-metrics.svg` so the Executive Dashboard section works even when metrics aren't generated

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687840c91bf8832bb92cf76b1623cc03